### PR TITLE
add inspect character columns in summary

### DIFF
--- a/minimal-edi-package.Rmd
+++ b/minimal-edi-package.Rmd
@@ -17,6 +17,7 @@ library(EMLassemblyline)
 library(ediutilities)
 library(here)
 library(lubridate)
+library(pandr)
 ```
 
 Read example data table
@@ -29,7 +30,11 @@ data_table$date = ymd_hms(data_table$date)
 Generate basic summary of data table
 
 ```{r}
-summary(data_table)
+# Just for inspecting the summary: change all character columns to factor
+DF <- data_table
+DF[sapply(DF, is.character)] <- lapply(DF[sapply(DF, is.character)], as.factor)
+pander::pander(summary(DF))
+
 ```
 
 Read the Excel metadata template and generate text templates used by


### PR DESCRIPTION
fixes #11 

To test: run minimal-edi-package.Rmd and observe in the terminal window that a readable summary of all columns in nes-lter-minimal.csv are displayed.