### PR TITLE
fix typo library(pandr)->library(pander)

### DIFF
--- a/minimal-edi-package.Rmd
+++ b/minimal-edi-package.Rmd
@@ -17,7 +17,7 @@ library(EMLassemblyline)
 library(ediutilities)
 library(here)
 library(lubridate)
-library(pandr)
+library(pander)
 ```
 
 Read example data table


### PR DESCRIPTION
fixes #14 

To test: run minimal-edi-package.Rmd and verify library pandr not found error does not appear.